### PR TITLE
Add status.compareBranches to config

### DIFF
--- a/git/workflows.gitconfig
+++ b/git/workflows.gitconfig
@@ -8,3 +8,5 @@
 	rebase = true
 [rebase]
     autoStash = true
+[status]
+    compareBranches= "@{upstream} @{push}"


### PR DESCRIPTION
Changes git workflow config to show status against both upstream and push remotes, which is useful for the triangular workflow.